### PR TITLE
Add support for a REDIS_TIMEOUT variable in config/environments

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -40,8 +40,17 @@ env_file = File.expand_path(File.dirname(__FILE__) + "/./environments/#{environm
 require env_file
 require 'assembly-image'
 
+# Load Resque configuration and controller
 require 'resque'
-REDIS_URL ||= "localhost:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"
-Resque.redis = REDIS_URL
-
+begin
+  if defined? REDIS_TIMEOUT
+    _server, _namespace = REDIS_URL.split('/', 2)
+    _host, _port, _db = _server.split(':')
+    _redis = Redis.new(:host => _host, :port => _port, :thread_safe => true, :db => _db, :timeout => REDIS_TIMEOUT.to_f)
+    Resque.redis = Redis::Namespace.new(_namespace, :redis => _redis)
+  else
+    Resque.redis = REDIS_URL
+  end
+end
+require 'active_support/core_ext' # camelcase
 require 'robot-controller'

--- a/config/environments/local.example.rb
+++ b/config/environments/local.example.rb
@@ -45,4 +45,5 @@ Dor::Config.configure do
 
 end
 
-REDIS_URL ||= "sul-lyberservices-dev.stanford.edu:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"
+REDIS_URL = "sul-lyberservices-dev.stanford.edu:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"
+#REDIS_TIMEOUT = '5' # seconds

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -48,3 +48,4 @@ Dor::Config.configure do
 end
 
 REDIS_URL ||= "localhost:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"
+#REDIS_TIMEOUT = '5' # seconds


### PR DESCRIPTION
This PR changes the boot.rb to (optionally) set a REDIS_TIMEOUT if there is a value for it. By default, it uses the default configure API.