### PR TITLE
Rescue load errors when rspec isn't available

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,10 +10,11 @@ task :app_version do
   puts File.read(File.expand_path('../VERSION', __FILE__)).match('[\w\.]+')[0]
 end
 
-require 'rspec/core/rake_task'
-
-desc "Run specs"
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
 
 task :default => :spec
 


### PR DESCRIPTION
Because rspec is in the `:test` group, it isn't loaded when running in a production environment. The rspec documentation [1] suggests the approach used here.

[1] https://www.relishapp.com/rspec/rspec-core/docs/command-line/rake-task