### PR TITLE
Update whenever gem roles for verify cron

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-every 5.minutes, :roles => [:app] =>  do
+every 5.minutes, :roles [:app] =>  do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
   set :environment_variable, 'ROBOT_ENVIRONMENT'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-every 5.minutes, :roles [:app] =>  do
+every 5.minutes, :roles [:app]  do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
   set :environment_variable, 'ROBOT_ENVIRONMENT'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-every 5.minutes do
+every 5.minutes, :roles => [:app] =>  do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
   set :environment_variable, 'ROBOT_ENVIRONMENT'


### PR DESCRIPTION
By default, the whenever gem only deploys to servers with the :db role. Based on the config/environments/[environment].rb, the cron is only being pushed to the first server in the list. To rectify the problem, I'm updating the cron to push to all servers that get the :app role