### PR TITLE
put back the =>

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,4 +1,4 @@
-every 5.minutes, :roles [:app]  do
+every 5.minutes, :roles => [:app]  do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
   set :environment_variable, 'ROBOT_ENVIRONMENT'


### PR DESCRIPTION
when running cap deploy you get...

(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Command::Failed: bundle stdout: Nothing written
bundle stderr: Nothing written

Tasks: TOP => whenever:update_crontab
(See full trace by running task with --trace)
The deploy has failed with an error: bundle stdout: Nothing written
bundle stderr: Nothing written

putting back the => fixes the problem.