### PR TITLE
Remove unnecessary requires in boot.rb

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -31,28 +31,17 @@ require 'assembly/accessioning_initiate'
 require 'assembly/checksum_compute'
 require 'assembly/exif_collect'
 require 'assembly/jp2_create'
-require 'content_metadata'
-require 'accessionable'
 require 'assembly'
-require 'checksumable'
-require 'exifable'
-require 'findable'
-require 'item'
-require 'jp2able'
-
 
 # Require the project and environment.
 # These requires need to come after the autoload code; otherwise, you
 # get a warning about an already-initialized constant.
 env_file = File.expand_path(File.dirname(__FILE__) + "/./environments/#{environment}")
 require env_file
-
-require 'assembly'
 require 'assembly-image'
 
 require 'resque'
 REDIS_URL ||= "localhost:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"
 Resque.redis = REDIS_URL
 
-require 'active_support/core_ext' # camelcase
 require 'robot-controller'

--- a/lib/assembly.rb
+++ b/lib/assembly.rb
@@ -1,5 +1,4 @@
 require 'content_metadata'
-
 require 'jp2able'
 require 'checksumable'
 require 'exifable'
@@ -8,10 +7,8 @@ require 'findable'
 require 'item'
 
 Dor::Config.configure do
-
   assembly do
-    jp2_resource_types  ['page','image']    # only file nodes in resources of this 'type' will have jp2 derivatives made, and only if they are valid image mimetypes as defined by the assembly-objectfile gem
+    jp2_resource_types  ['page','image']   # only file nodes in resources of this 'type' will have jp2 derivatives made, and only if they are valid image mimetypes as defined by the assembly-objectfile gem
     items_only          true               # exif-collect, checksum-compute and jp2aable only operate on dor type="item" if this is set to true
   end
-
 end


### PR DESCRIPTION
- Duplicate active_support require
- Duplicate `assembly` require
- assembly already requires many subparts, so when we require assembly we get them, too.

Further cleanup could probably be pursued.