### PR TITLE
Bump dor-services to 5.x, remove assembly-utils dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pid
 tags
 tmp
 .ruby-*
+workflow_service.log*

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,11 @@ gem "lyber-core", "~> 3", ">= 3.2.2"
 gem "addressable", "2.3.5" # specs won't run with 2.3.6
 gem "assembly-objectfile", ">=1.6.6"
 gem "assembly-image", ">=1.6.6"
-gem "assembly-utils"
 gem "rest-client", '>=1.8'
 gem "rake"
 gem "druid-tools"
 gem "mini_exiftool", "~> 1.6"
-gem "dor-services", "~> 4.21"
+gem "dor-services", "~> 5.3"
 gem "nokogiri"
 gem 'resque'
 gem "pry-debugger", '0.2.2', :platform => :ruby_19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    active-fedora (5.7.1)
-      activeresource (>= 3.0.0)
+    active-fedora (6.7.3)
       activesupport (>= 3.0.0)
-      builder (~> 3.0.0)
       deprecation
       mediashelf-loggable
       nom-xml (>= 0.5.1)
-      om (~> 1.8.0)
+      om (~> 3.0.0)
       rdf
-      rdf-rdfxml (~> 0.3.8)
+      rdf-rdfxml (= 1.0.1)
       rsolr
-      rubydora (~> 1.6)
-      solrizer (~> 2.1)
-    activemodel (3.2.22)
-      activesupport (= 3.2.22)
-      builder (~> 3.0.0)
-    activeresource (3.2.22)
-      activemodel (= 3.2.22)
-      activesupport (= 3.2.22)
-    activesupport (3.2.22)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+      rubydora (~> 1.6, >= 1.6.5)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
+      builder (~> 3.1)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.3.5)
     assembly-image (1.6.8)
       activesupport (> 3)
@@ -33,16 +30,6 @@ GEM
     assembly-objectfile (1.6.6)
       mime-types
       mini_exiftool
-      nokogiri
-    assembly-utils (1.4.5)
-      activeresource
-      activesupport
-      addressable (= 2.3.5)
-      csv-mapper
-      dor-services (~> 4.19)
-      dor-workflow-service (>= 1.3.1)
-      druid-tools (>= 0.2.6)
-      fastercsv
       nokogiri
     awesome_print (1.6.1)
     bagit (0.3.2)
@@ -56,7 +43,7 @@ GEM
       blue-daemons (~> 1.1.11)
       i18n (~> 0.5)
       state_machine (~> 1.1)
-    builder (3.0.4)
+    builder (3.2.2)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -81,8 +68,6 @@ GEM
     coderay (1.1.0)
     columnize (0.9.0)
     confstruct (0.2.7)
-    csv-mapper (0.5.1)
-      fastercsv
     daemons (1.2.3)
     debug_inspector (0.0.2)
     debugger (1.6.8)
@@ -95,46 +80,52 @@ GEM
       activesupport
     diff-lcs (1.2.5)
     docopt (0.5.0)
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services (4.21.4)
-      active-fedora (~> 5.7.1)
-      activesupport (~> 3.2, >= 3.2.18)
-      addressable (= 2.3.5)
+    dor-rights-auth (1.0.2)
+      nokogiri
+    dor-services (5.3.0)
+      active-fedora (~> 6.0)
+      activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
-      dor-workflow-service (~> 1.7, >= 1.7.1)
+      dor-rights-auth (~> 1.0, >= 1.0.2)
+      dor-workflow-service (~> 1.8, >= 1.8.0)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
       json (~> 1.8.1)
       lyber-utils (~> 0.1.2)
       moab-versioning (~> 1.4.4)
+      modsulator (~> 0.0.7)
       net-sftp (~> 2.1.2)
       net-ssh (~> 2.6.5)
       nokogiri (~> 1.6.0)
-      om (~> 1.8.0)
+      nokogiri-pretty (~> 0.1.0)
+      om (~> 3.0)
       osullivan (~> 0.0.3)
       progressbar (~> 0.21.0)
-      rdf (~> 1.0.9.0)
+      rdf (~> 1.1.7)
       rest-client (~> 1.7)
       retries
       rsolr-ext (~> 1.0.3)
       ruby-cache (~> 0.3.0)
-      ruby-graphviz (~> 1.0.9)
+      ruby-graphviz
       rubydora (~> 1.6.5)
-      solrizer (~> 2.0)
-      stanford-mods (~> 0.0.14)
+      solrizer (~> 3.0)
+      stanford-mods (~> 1.1)
       systemu (~> 2.6.0)
       uuidtools (~> 2.1.4)
-      validatable (~> 1.6.7)
-    dor-workflow-service (1.7.6)
+    dor-workflow-service (1.8.0)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
+      faraday (~> 0.9.2)
+      net-http-persistent (~> 2.9.4)
       nokogiri (~> 1.6.0)
       rest-client (~> 1.7)
+      retries
     druid-tools (0.4.1)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     hooks (0.3.6)
@@ -145,6 +136,7 @@ GEM
     interception (0.5)
     iso-639 (0.2.5)
     json (1.8.3)
+    link_header (0.0.8)
     lyber-core (3.3.0)
       dor-workflow-service (~> 1.7)
     lyber-utils (0.1.2)
@@ -159,9 +151,10 @@ GEM
       capistrano-releaseboard
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
-    mime-types (2.6.1)
+    mime-types (2.99)
     mini_exiftool (1.7.0)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
+    minitest (5.8.3)
     moab-versioning (1.4.4)
       confstruct
       json
@@ -172,29 +165,38 @@ GEM
       iso-639
       nokogiri
       nom-xml (~> 0.5.2)
+    modsulator (0.0.7)
+      activesupport (>= 3.0)
+      equivalent-xml (>= 0.6.0)
+      nokogiri
+      roo (>= 1.1)
     mono_logger (1.1.0)
     multi_json (1.11.2)
     multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (2.6.8)
-    netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    netrc (0.11.0)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
-    nom-xml (0.5.3)
+    nokogiri-pretty (0.1.0)
+      nokogiri
+    nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    om (1.8.0)
+    om (3.0.7)
       activemodel
       activesupport
       deprecation
       mediashelf-loggable
       nokogiri (>= 1.4.2)
+      solrizer (~> 3.1.0)
     osullivan (0.0.3)
       activesupport (>= 3.2.18)
       faraday (~> 0.9.0)
@@ -217,14 +219,13 @@ GEM
     rack-protection (1.5.3)
       rack
     rake (10.4.2)
-    rdf (1.0.9)
-      addressable (>= 2.3)
-    rdf-rdfxml (0.3.9)
-      rdf (>= 0.3.11)
-      rdf-xsd (>= 0.3.8)
-    rdf-xsd (1.0.2.1)
-      nokogiri (>= 1.5.0)
-      rdf (>= 0.3.4)
+    rdf (1.1.17.1)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-rdfxml (1.0.1)
+      rdf (>= 1.0)
+      rdf-xsd (>= 1.0)
+    rdf-xsd (1.1.5.1)
+      rdf (~> 1.1, >= 1.1.9, < 1.99)
     redis (3.2.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
@@ -244,7 +245,10 @@ GEM
       rake (~> 10.3)
       resque (~> 1.25.2)
       whenever (~> 0.9.2)
-    rsolr (1.0.12)
+    roo (2.3.0)
+      nokogiri (~> 1)
+      rubyzip (~> 1.1, < 2.0.0)
+    rsolr (1.0.13)
       builder (>= 2.1.2)
     rsolr-ext (1.0.3)
       rsolr (>= 1.0.2)
@@ -257,7 +261,7 @@ GEM
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.4)
     ruby-cache (0.3.0)
-    ruby-graphviz (1.0.9)
+    ruby-graphviz (1.2.2)
     rubydora (1.6.5)
       activemodel
       activesupport
@@ -268,34 +272,37 @@ GEM
       mime-types
       nokogiri
       rest-client
+    rubyzip (1.1.7)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
-    solrizer (2.2.0)
+    solrizer (3.1.1)
       activesupport
       daemons
       mediashelf-loggable (~> 0.4.7)
       nokogiri
-      om (>= 1.5.0)
       stomp
       xml-simple
     sshkit (1.3.0)
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (0.0.27)
-      mods
+    stanford-mods (1.3.3)
+      mods (~> 2.0.2)
     state_machine (1.2.0)
     stomp (1.3.4)
     systemu (2.6.5)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.5)
     tilt (2.0.1)
     tins (1.5.4)
-    uber (0.0.13)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uber (0.0.15)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -315,12 +322,11 @@ DEPENDENCIES
   addressable (= 2.3.5)
   assembly-image (>= 1.6.6)
   assembly-objectfile (>= 1.6.6)
-  assembly-utils
   awesome_print
   capistrano (~> 3)
   capistrano-bundler
   capistrano-rvm
-  dor-services (~> 4.21)
+  dor-services (~> 5.3)
   druid-tools
   equivalent-xml
   lyber-core (~> 3, >= 3.2.2)
@@ -337,6 +343,3 @@ DEPENDENCIES
   rspec (~> 2.6)
   slop
   yard
-
-BUNDLED WITH
-   1.10.6

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,5 @@
 require 'rubygems'
 require 'bundler/setup'
-require 'active_support/core_ext'
 
 # Environment and robot root directory.
 environment = ENV['ROBOT_ENVIRONMENT'] ||= 'development'
@@ -28,7 +27,6 @@ end
 require 'dor-services'
 require 'lyber_core'
 
-
 require 'assembly/accessioning_initiate'
 require 'assembly/checksum_compute'
 require 'assembly/exif_collect'
@@ -51,7 +49,6 @@ require env_file
 
 require 'assembly'
 require 'assembly-image'
-require 'assembly-utils'
 
 require 'resque'
 REDIS_URL ||= "localhost:6379/resque:#{ENV['ROBOT_ENVIRONMENT']}"

--- a/lib/findable.rb
+++ b/lib/findable.rb
@@ -21,12 +21,12 @@ module Dor::Assembly
 
     # new style path, e.g. aa/111/bb/2222/aa111bb2222
     def druid_tree_path(root_dir)
-      DruidTools::Druid.new(@druid.id,root_dir).path()
+      DruidTools::Druid.new(@druid.id, root_dir).path
     end
 
     # old style path, e.g. aa/111/bb/2222
     def old_druid_tree_path(root_dir)
-      Assembly::Utils.get_staging_path(@druid.id,root_dir)
+      File.dirname druid_tree_path(root_dir)
     end
 
     # returns the location of a content file, which can be in the old location if not found in the new location, e.g.  aa/111/bb/2222/aa111bb2222/content or  aa/111/bb/2222/

--- a/spec/lib/content_metadata_spec.rb
+++ b/spec/lib/content_metadata_spec.rb
@@ -18,19 +18,17 @@ describe Dor::Assembly::ContentMetadata do
   end
 
   describe "#load_content_metadata" do
-
     it "should load a Nokogiri doc in @cm" do
       basic_setup 'aa111bb2222'
       @item.cm = nil
       @item.load_content_metadata
       @item.cm.should be_kind_of Nokogiri::XML::Document
     end
-
   end
 
   describe "#persist_content_metadata" do
 
-    before(:each) do
+    before :each do
       basic_setup 'aa111bb2222'
       @tmp_dir           = 'tmp'
       @dummy_xml_content = "<xml><foobar /></xml>\n"
@@ -58,9 +56,11 @@ describe Dor::Assembly::ContentMetadata do
   end
 
   describe "Helper methods" do
+    before :each do
+      basic_setup 'aa111bb2222'
+    end
 
     it "#new_node_in_cm should return the expected Nokogiri element" do
-      basic_setup 'aa111bb2222'
       @item.load_content_metadata
       n = @item.new_node_in_cm 'foo'
       n.to_s.should == '<foo/>'
@@ -68,31 +68,27 @@ describe Dor::Assembly::ContentMetadata do
     end
 
     it "#path_to_object should return nil when no content folder is not found" do
-      basic_setup 'aa111bb2222'
       @item.root_dir = 'foo/bar'
       @item.druid = DruidTools::Druid.new 'xx999yy8888'
       @item.path_to_object.should be nil
     end
 
     it "#path_to_object should return the expected string when the new druid folder is found" do
-      basic_setup 'aa111bb2222'
       @item.root_dir = TMP_ROOT_DIR
-      @item.druid = DruidTools::Druid.new('xx999yy8888',@item.root_dir)
-      FileUtils.mkdir_p @item.druid.path()
+      @item.druid = DruidTools::Druid.new 'xx999yy8888', @item.root_dir
+      FileUtils.mkdir_p @item.druid.path
       @item.path_to_object.should == 'tmp/test_input/xx/999/yy/8888/xx999yy8888'
-      FileUtils.rm_rf @item.druid.path()
+      FileUtils.rm_rf @item.druid.path
     end
 
     it "#path_to_object should return the expected string when the new druid folder is not found, but the older druid style folder is found" do
-      basic_setup 'aa111bb2222'
       @item.root_dir = TMP_ROOT_DIR
-      path=Assembly::Utils.get_staging_path('xx999yy8888',@item.root_dir)
-      @item.druid = DruidTools::Druid.new('xx999yy8888',@item.root_dir)
+      @item.druid = DruidTools::Druid.new 'xx999yy8888', @item.root_dir
+      path = @item.old_druid_tree_path(@item.root_dir)
       FileUtils.mkdir_p path
       @item.path_to_object.should == 'tmp/test_input/xx/999/yy/8888'
       FileUtils.rm_rf path
     end
-
   end
 
   describe "Methods returning <file> nodes and filenode-Image tuples" do


### PR DESCRIPTION
There was only one call that needed to be replaced and it was to a trivial 2-line method.

Closes #19  