### PR TITLE
Convert specs to RSpec 3.4.2 syntax with Transpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'slop'
 group :test do
   gem 'equivalent-xml'
   gem 'yard'
-  gem "rspec", "~> 2.6"
+  gem 'rspec', '~> 3.4'
 end
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,14 +252,19 @@ GEM
       builder (>= 2.1.2)
     rsolr-ext (1.0.3)
       rsolr (>= 1.0.2)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.4)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.2)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     ruby-cache (0.3.0)
     ruby-graphviz (1.2.2)
     rubydora (1.6.5)
@@ -340,6 +345,9 @@ DEPENDENCIES
   resque
   rest-client (>= 1.8)
   robot-controller (~> 2.0)
-  rspec (~> 2.6)
+  rspec (~> 3.4)
   slop
   yard
+
+BUNDLED WITH
+   1.11.2

--- a/spec/lib/accessionable_spec.rb
+++ b/spec/lib/accessionable_spec.rb
@@ -16,25 +16,25 @@ describe Dor::Assembly::Accessionable do
 
   describe '#AccessionableItem' do
     it 'should be able to initialize our testing object' do
-      @item.should be_a_kind_of AccessionableItem
+      expect(@item).to be_a_kind_of AccessionableItem
     end
   end
 
   describe '#initiate_accessioning' do
 
     it 'should be runnable using stubs for external calls for an item type object' do
-      @item.stub(:object_type).and_return('item')
-      @item.should_receive(:initialize_workspace)
-      @item.should_receive(:initialize_apo_workflow)
-      RestClient.stub(:post) # don't actually make the RestClient calls, just assume they work
+      allow(@item).to receive(:object_type).and_return('item')
+      expect(@item).to receive(:initialize_workspace)
+      expect(@item).to receive(:initialize_apo_workflow)
+      allow(RestClient).to receive(:post) # don't actually make the RestClient calls, just assume they work
       @item.initiate_accessioning
     end
 
     it 'should be runnable using stubs for external calls for a collection type object' do
-      @item.stub(:object_type).and_return('collection')
-      @item.should_receive(:initialize_workspace)
-      @item.should_receive(:initialize_apo_workflow)
-      RestClient.stub(:post) # don't actually make the RestClient calls, just assume they work
+      allow(@item).to receive(:object_type).and_return('collection')
+      expect(@item).to receive(:initialize_workspace)
+      expect(@item).to receive(:initialize_apo_workflow)
+      allow(RestClient).to receive(:post) # don't actually make the RestClient calls, just assume they work
       @item.initiate_accessioning
     end
 

--- a/spec/lib/checksumable_spec.rb
+++ b/spec/lib/checksumable_spec.rb
@@ -41,7 +41,7 @@ describe Dor::Assembly::Checksumable do
 
     it "should be able to initialize our testing object" do
       basic_setup('aa111bb2222')
-      @item.should be_a_kind_of ChecksumableItem
+      expect(@item).to be_a_kind_of ChecksumableItem
     end
 
   end
@@ -54,9 +54,9 @@ describe Dor::Assembly::Checksumable do
       setup_tmp_handle
 
       @item.load_content_metadata
-      all_cs_nodes.size.should == 5
+      expect(all_cs_nodes.size).to eq(5)
       @item.compute_checksums
-      all_cs_nodes.size.should == 8
+      expect(all_cs_nodes.size).to eq(8)
 
       @exp_checksums = {
         "image111.tif" => {
@@ -78,7 +78,7 @@ describe Dor::Assembly::Checksumable do
         file_name = fnode['id']
         cnodes    = fnode.xpath './checksum'
         checksums = Hash[ cnodes.map { |cn| [cn['type'], cn.content] } ]
-        checksums.should == @exp_checksums[file_name]
+        expect(checksums).to eq(@exp_checksums[file_name])
       end
     end
 
@@ -88,9 +88,9 @@ describe Dor::Assembly::Checksumable do
       setup_tmp_handle
 
       @item.load_content_metadata
-      all_cs_nodes.size.should == 4
+      expect(all_cs_nodes.size).to eq(4)
       @item.compute_checksums
-      all_cs_nodes.size.should == 7
+      expect(all_cs_nodes.size).to eq(7)
 
       @exp_checksums = {
         "image111.tif" => {
@@ -112,7 +112,7 @@ describe Dor::Assembly::Checksumable do
         file_name = fnode['id']
         cnodes    = fnode.xpath './checksum'
         checksums = Hash[ cnodes.map { |cn| [cn['type'], cn.content] } ]
-        checksums.should == @exp_checksums[file_name]
+        expect(checksums).to eq(@exp_checksums[file_name])
       end
     end
 
@@ -124,13 +124,13 @@ describe Dor::Assembly::Checksumable do
       @item.load_content_metadata
 
       all_file_nodes[0].xpath('checksum[@type="md5"]')[0].content='42616f9E6C1B7E7B7A71B4FA0C5Ef794'  # change the md5 hash in the first file node to be all caps
-      all_cs_nodes.size.should == 5
+      expect(all_cs_nodes.size).to eq(5)
 
       # now check that it was re-computed and still succeeds
-      lambda { @item.compute_checksums }.should_not raise_error
+      expect { @item.compute_checksums }.not_to raise_error
 
       # this was the first file node it got to, so no new checksums were added
-      all_cs_nodes.size.should == 8
+      expect(all_cs_nodes.size).to eq(8)
 
     end
 
@@ -142,14 +142,14 @@ describe Dor::Assembly::Checksumable do
       @item.load_content_metadata
 
       all_file_nodes[0].xpath('checksum[@type="md5"]')[0].content='flimflam'  # change the md5 hash in the first file node
-      all_cs_nodes.size.should == 5
+      expect(all_cs_nodes.size).to eq(5)
 
       # now check that it was re-computed and failed
       exp_msg = /^Checksums disagree: type="md5", file="image111.tif"./
-      lambda { @item.compute_checksums }.should raise_error RuntimeError, exp_msg
+      expect { @item.compute_checksums }.to raise_error RuntimeError, exp_msg
 
       # this was the first file node it got to, so no new checksums were added before it failed
-      all_cs_nodes.size.should == 5
+      expect(all_cs_nodes.size).to eq(5)
 
     end
 
@@ -161,14 +161,14 @@ describe Dor::Assembly::Checksumable do
       @item.load_content_metadata
 
       all_file_nodes[0].xpath('checksum[@type="md5"]')[0].content='flimflam'  # change the md5 hash in the first file node
-      all_cs_nodes.size.should == 4
+      expect(all_cs_nodes.size).to eq(4)
 
       # now check that it was re-computed and failed
       exp_msg = /^Checksums disagree: type="md5", file="image111.tif"./
-      lambda { @item.compute_checksums }.should raise_error RuntimeError, exp_msg
+      expect { @item.compute_checksums }.to raise_error RuntimeError, exp_msg
 
       # this was the first file node it got to, so no new checksums were added before it failed
-      all_cs_nodes.size.should == 4
+      expect(all_cs_nodes.size).to eq(4)
 
     end
 
@@ -180,14 +180,14 @@ describe Dor::Assembly::Checksumable do
       @item.load_content_metadata
       all_file_nodes[1].xpath('checksum[@type="sha1"]')[0].content='crapola'  # change the md5 hash in the first file node
 
-      all_cs_nodes.size.should == 5
+      expect(all_cs_nodes.size).to eq(5)
 
       # now check that it was re-computed and failed
       exp_msg = /^Checksums disagree: type="sha1", file="image112.tif"./
-      lambda { @item.compute_checksums }.should raise_error RuntimeError, exp_msg
+      expect { @item.compute_checksums }.to raise_error RuntimeError, exp_msg
 
       # at this point it added a sha1 checksum to the first file node already
-      all_cs_nodes.size.should == 6
+      expect(all_cs_nodes.size).to eq(6)
 
     end
 
@@ -199,20 +199,20 @@ describe Dor::Assembly::Checksumable do
       @item.load_content_metadata
 
       # start out with 5 checksum nodes
-      all_cs_nodes.size.should == 5
+      expect(all_cs_nodes.size).to eq(5)
 
       # keep the correct first md5 checksum for the first file, but add a bogous one too
       @item.add_checksum_node @item.cm.xpath('//file').first, 'md5','junk'
 
       # we now have six checksum nodes
-      all_cs_nodes.size.should == 6
+      expect(all_cs_nodes.size).to eq(6)
 
       # now check that it was re-computed and failed, even though the first still matches
       exp_msg = /^Checksums disagree: type="md5", file="image111.tif"./
-      lambda { @item.compute_checksums }.should raise_error RuntimeError, exp_msg
+      expect { @item.compute_checksums }.to raise_error RuntimeError, exp_msg
 
       # this was the first file node it got to, so no new checksums were added before it failed
-      all_cs_nodes.size.should == 6
+      expect(all_cs_nodes.size).to eq(6)
 
     end
 
@@ -224,12 +224,12 @@ describe Dor::Assembly::Checksumable do
     it "should correctly add checksum nodes as children of the parent_node" do
       basic_setup('aa111bb2222')
 
-      all_cs_nodes.size.should == 0
+      expect(all_cs_nodes.size).to eq(0)
       @item.add_checksum_node @parent_file_node, 'md5',@fake_checksum_data[:md5]
       @item.add_checksum_node @parent_file_node, 'sha1',@fake_checksum_data[:sha1]
-      all_cs_nodes.size.should == 2
+      expect(all_cs_nodes.size).to eq(2)
       h = Hash[ all_cs_nodes.map { |n| [ n['type'].to_sym, n.content ] } ]
-      h.should == @fake_checksum_data
+      expect(h).to eq(@fake_checksum_data)
     end
 
   end

--- a/spec/lib/content_metadata_spec.rb
+++ b/spec/lib/content_metadata_spec.rb
@@ -22,7 +22,7 @@ describe Dor::Assembly::ContentMetadata do
       basic_setup 'aa111bb2222'
       @item.cm = nil
       @item.load_content_metadata
-      @item.cm.should be_kind_of Nokogiri::XML::Document
+      expect(@item.cm).to be_kind_of Nokogiri::XML::Document
     end
   end
 
@@ -33,7 +33,7 @@ describe Dor::Assembly::ContentMetadata do
       @tmp_dir           = 'tmp'
       @dummy_xml_content = "<xml><foobar /></xml>\n"
       @item.load_content_metadata
-      @item.cm.stub(:to_xml).and_return @dummy_xml_content
+      allow(@item.cm).to receive(:to_xml).and_return @dummy_xml_content
     end
 
     it "should write to @cm_handle, if @cm_handle is set" do
@@ -41,16 +41,16 @@ describe Dor::Assembly::ContentMetadata do
       @item.cm_handle = tf
       @item.persist_content_metadata
       tf.close
-      File.read(tf.path).should == @dummy_xml_content
+      expect(File.read(tf.path)).to eq(@dummy_xml_content)
     end
 
     it "should write to @cm_file_name, if @cm_handle is not set" do
       tf = File.join @tmp_dir, 'out.xml'
       FileUtils.rm_f tf
-      File.exists?(tf).should == false
+      expect(File.exists?(tf)).to eq(false)
       @item.cm_file_name = tf
       @item.persist_content_metadata
-      File.read(tf).should == @dummy_xml_content
+      expect(File.read(tf)).to eq(@dummy_xml_content)
     end
 
   end
@@ -63,21 +63,21 @@ describe Dor::Assembly::ContentMetadata do
     it "#new_node_in_cm should return the expected Nokogiri element" do
       @item.load_content_metadata
       n = @item.new_node_in_cm 'foo'
-      n.to_s.should == '<foo/>'
-      n.should be_kind_of Nokogiri::XML::Element
+      expect(n.to_s).to eq('<foo/>')
+      expect(n).to be_kind_of Nokogiri::XML::Element
     end
 
     it "#path_to_object should return nil when no content folder is not found" do
       @item.root_dir = 'foo/bar'
       @item.druid = DruidTools::Druid.new 'xx999yy8888'
-      @item.path_to_object.should be nil
+      expect(@item.path_to_object).to be nil
     end
 
     it "#path_to_object should return the expected string when the new druid folder is found" do
       @item.root_dir = TMP_ROOT_DIR
       @item.druid = DruidTools::Druid.new 'xx999yy8888', @item.root_dir
       FileUtils.mkdir_p @item.druid.path
-      @item.path_to_object.should == 'tmp/test_input/xx/999/yy/8888/xx999yy8888'
+      expect(@item.path_to_object).to eq('tmp/test_input/xx/999/yy/8888/xx999yy8888')
       FileUtils.rm_rf @item.druid.path
     end
 
@@ -86,7 +86,7 @@ describe Dor::Assembly::ContentMetadata do
       @item.druid = DruidTools::Druid.new 'xx999yy8888', @item.root_dir
       path = @item.old_druid_tree_path(@item.root_dir)
       FileUtils.mkdir_p path
-      @item.path_to_object.should == 'tmp/test_input/xx/999/yy/8888'
+      expect(@item.path_to_object).to eq('tmp/test_input/xx/999/yy/8888')
       FileUtils.rm_rf path
     end
   end
@@ -97,27 +97,27 @@ describe Dor::Assembly::ContentMetadata do
       basic_setup 'aa111bb2222'
       @item.load_content_metadata
       fns = @item.file_nodes
-      fns.size.should == 3
-      fns.each { |fn| fn.should be_kind_of Nokogiri::XML::Element }
+      expect(fns.size).to eq(3)
+      fns.each { |fn| expect(fn).to be_kind_of Nokogiri::XML::Element }
     end
 
     it "#file_nodes should return the expected N of Nokogiri elements with new content metadata location" do
       basic_setup 'gg111bb2222'
       @item.load_content_metadata
       fns = @item.file_nodes
-      fns.size.should == 3
-      fns.each { |fn| fn.should be_kind_of Nokogiri::XML::Element }
+      expect(fns.size).to eq(3)
+      fns.each { |fn| expect(fn).to be_kind_of Nokogiri::XML::Element }
     end
 
     it "#fnode_tuples should load the correct N of Node-Image pairs" do
       basic_setup 'aa111bb2222'
       @item.load_content_metadata
       objs = @item.fnode_tuples
-      objs.size.should == 3
+      expect(objs.size).to eq(3)
       objs.each { |file_node, obj|
-        file_node.should be_instance_of Nokogiri::XML::Element
-        obj.should be_instance_of Assembly::ObjectFile
-        obj.object_type.should == :image
+        expect(file_node).to be_instance_of Nokogiri::XML::Element
+        expect(obj).to be_instance_of Assembly::ObjectFile
+        expect(obj.object_type).to eq(:image)
       }
     end
 
@@ -125,9 +125,9 @@ describe Dor::Assembly::ContentMetadata do
       basic_setup 'cc333dd4444'
       @item.load_content_metadata
       objs = @item.fnode_tuples
-      objs.size.should == 2
-      objs[0][1].object_type.should == :image # first file is a tiff
-      objs[1][1].object_type.should == :text  # second file is a txt
+      expect(objs.size).to eq(2)
+      expect(objs[0][1].object_type).to eq(:image) # first file is a tiff
+      expect(objs[1][1].object_type).to eq(:text)  # second file is a txt
     end
 
   end

--- a/spec/lib/exifable_spec.rb
+++ b/spec/lib/exifable_spec.rb
@@ -33,46 +33,46 @@ describe Dor::Assembly::Exifable do
     aft = Nokogiri::XML File.read(@item.cm_file_name)
 
     # check that the contentmetadata resource type is image after
-    bef.root['type'].should == nil
-    aft.root['type'].should == 'image'
+    expect(bef.root['type']).to eq(nil)
+    expect(aft.root['type']).to eq('image')
 
     # check that each file node does not start with size, mimetype attributes
     bef_file_nodes=bef.xpath('//file')
-    bef_file_nodes.size.should == 3
+    expect(bef_file_nodes.size).to eq(3)
     bef_file_nodes.each do |file_node|
-      file_node.attributes['size'].nil?.should == true
-      file_node.attributes['mimetype'].nil?.should == true
+      expect(file_node.attributes['size'].nil?).to eq(true)
+      expect(file_node.attributes['mimetype'].nil?).to eq(true)
     end
 
     # check that each resource node starts out with type=image
     bef_res_nodes=bef.xpath('//resource')
-    bef_res_nodes.size.should == 3
+    expect(bef_res_nodes.size).to eq(3)
     bef_res_nodes.each do |res_node|
-      res_node.attributes['type'].value.should == 'image'
+      expect(res_node.attributes['type'].value).to eq('image')
     end
 
     # check that each file node now has size, mimetype
     aft_file_nodes=aft.xpath('//file')
-    aft_file_nodes.size.should == 3
-    aft_file_nodes[0].attributes['size'].value.should == '63468'
-    aft_file_nodes[1].attributes['size'].value.should == '63472'
-    aft_file_nodes.each {|file_node| file_node.attributes['mimetype'].value.should == 'image/tiff'}
+    expect(aft_file_nodes.size).to eq(3)
+    expect(aft_file_nodes[0].attributes['size'].value).to eq('63468')
+    expect(aft_file_nodes[1].attributes['size'].value).to eq('63472')
+    aft_file_nodes.each {|file_node| expect(file_node.attributes['mimetype'].value).to eq('image/tiff')}
 
     # check that each resource node is still type=image
     aft_res_nodes=aft.xpath('//resource')
-    aft_res_nodes.size.should == 3
+    expect(aft_res_nodes.size).to eq(3)
     aft_res_nodes.each do |res_node|
-      res_node.attributes['type'].value.should == 'image'
+      expect(res_node.attributes['type'].value).to eq('image')
     end
 
     # check for imageData nodes being present for each file node
-    bef.xpath('//file/imageData').size.should == 0
-    aft.xpath('//file/imageData').size.should == 3
+    expect(bef.xpath('//file/imageData').size).to eq(0)
+    expect(aft.xpath('//file/imageData').size).to eq(3)
   end
 
   describe '#ExifableItem' do
     it 'should be able to initialize our testing object' do
-      @item.should be_a_kind_of ExifableItem
+      expect(@item).to be_a_kind_of ExifableItem
     end
   end
 
@@ -86,12 +86,12 @@ describe Dor::Assembly::Exifable do
       end
       exp = Nokogiri::XML( '<contentMetadata type="image"><resource type="image">' +
                            '</resource></contentMetadata>')
-      @item.cm.should be_equivalent_to exp
+      expect(@item.cm).to be_equivalent_to exp
     end
 
     it '#image_data_xml should return the expect XML text' do
       exif = double 'image_width' => 55, 'image_height' => 66
-      @item.image_data_xml(exif).should == '<imageData width="55" height="66"/>'
+      expect(@item.image_data_xml(exif)).to eq('<imageData width="55" height="66"/>')
     end
 
   end
@@ -125,40 +125,40 @@ describe Dor::Assembly::Exifable do
       aft = Nokogiri::XML File.read(@item.cm_file_name)
 
       # check that the content metadata type is image (default for only images)
-      bef.root['type'].nil?.should == true
-      aft.root['type'].should == 'image'
+      expect(bef.root['type'].nil?).to eq(true)
+      expect(aft.root['type']).to eq('image')
 
       # check that the first resource node starts with a type="page" and the second is blank
       bef_res_nodes=bef.xpath('//resource')
-      bef_res_nodes.size.should == 1
-      bef_res_nodes[0].attributes['type'].nil?.should == true  # first resource type should not exist
+      expect(bef_res_nodes.size).to eq(1)
+      expect(bef_res_nodes[0].attributes['type'].nil?).to eq(true)  # first resource type should not exist
 
       # check that each file node starts with size, mimetype attributes
       bef_file_nodes=bef.xpath('//file')
-      bef_file_nodes.size.should == 2
+      expect(bef_file_nodes.size).to eq(2)
       bef_file_nodes.each do |file_node|
-        file_node.attributes['size'].nil?.should == false
-        file_node.attributes['mimetype'].nil?.should == false
+        expect(file_node.attributes['size'].nil?).to eq(false)
+        expect(file_node.attributes['mimetype'].nil?).to eq(false)
       end
 
       # check that the file nodes still have bogus size, mimetype
       aft_file_nodes=aft.xpath('//file')
-      aft_file_nodes.size.should == 2
-      aft_file_nodes[0].attributes['size'].value.should == '100'
-      aft_file_nodes[0].attributes['mimetype'].value.should == 'crappy/mimetype'
+      expect(aft_file_nodes.size).to eq(2)
+      expect(aft_file_nodes[0].attributes['size'].value).to eq('100')
+      expect(aft_file_nodes[0].attributes['mimetype'].value).to eq('crappy/mimetype')
 
       # all other file nodes will have their publish/preserve/shelve attributes set
-      aft_file_nodes[1].attributes['size'].value.should == '500'
-      aft_file_nodes[1].attributes['mimetype'].value.should == 'crappy/again'
+      expect(aft_file_nodes[1].attributes['size'].value).to eq('500')
+      expect(aft_file_nodes[1].attributes['mimetype'].value).to eq('crappy/again')
 
       # check that each resource node end with a type="file" (i.e. was not changed)
       aft_res_nodes=aft.xpath('//resource')
-      aft_res_nodes.size.should == 1
-      aft_res_nodes[0].attributes['type'].value.should == 'file' # first resource type should be set to file (default when not all files are images)
+      expect(aft_res_nodes.size).to eq(1)
+      expect(aft_res_nodes[0].attributes['type'].value).to eq('file') # first resource type should be set to file (default when not all files are images)
 
       # check for imageData nodes being present for each file node that is an image
-      bef.xpath('//file/imageData').size.should == 0
-      aft.xpath('//file/imageData').size.should == 1
+      expect(bef.xpath('//file/imageData').size).to eq(0)
+      expect(aft.xpath('//file/imageData').size).to eq(1)
 
     end
 
@@ -175,108 +175,108 @@ describe Dor::Assembly::Exifable do
       aft = Nokogiri::XML File.read(@item.cm_file_name)
 
       # check that the content metadata type is preserved as file and not switched to image
-      bef.root['type'].should == 'file'
-      aft.root['type'].should == 'file'
+      expect(bef.root['type']).to eq('file')
+      expect(aft.root['type']).to eq('file')
 
       # check that the first resource node starts with a type="page" and the second is blank
       bef_res_nodes=bef.xpath('//resource')
-      bef_res_nodes.size.should == 5
-      bef_res_nodes[0].attributes['type'].nil?.should == true  # first resource type should not exist
-      bef_res_nodes[1].attributes['type'].nil?.should == true # second resource type should not exist
-      bef_res_nodes[2].attributes['type'].nil?.should == true # third resource type should not exist
-      bef_res_nodes[3].attributes['type'].value.should == 'page' # fourth resource type should be set to page
-      bef_res_nodes[4].attributes['type'].value.should == 'image' # last resource type should be set to image
+      expect(bef_res_nodes.size).to eq(5)
+      expect(bef_res_nodes[0].attributes['type'].nil?).to eq(true)  # first resource type should not exist
+      expect(bef_res_nodes[1].attributes['type'].nil?).to eq(true) # second resource type should not exist
+      expect(bef_res_nodes[2].attributes['type'].nil?).to eq(true) # third resource type should not exist
+      expect(bef_res_nodes[3].attributes['type'].value).to eq('page') # fourth resource type should be set to page
+      expect(bef_res_nodes[4].attributes['type'].value).to eq('image') # last resource type should be set to image
 
       # check that each file node does not start with size, mimetype attributes
       bef_file_nodes=bef.xpath('//file')
-      bef_file_nodes.size.should == 10
+      expect(bef_file_nodes.size).to eq(10)
       bef_file_nodes.each do |file_node|
-        file_node.attributes['size'].nil?.should == true
-        file_node.attributes['mimetype'].nil?.should == true
+        expect(file_node.attributes['size'].nil?).to eq(true)
+        expect(file_node.attributes['mimetype'].nil?).to eq(true)
         # the first file node as the publish/preserve/attributes already set, the others do not
         expected = (file_node == bef_file_nodes.first)? false : true
-        file_node.attributes['publish'].nil?.should == expected
-        file_node.attributes['preserve'].nil?.should == expected
-        file_node.attributes['shelve'].nil?.should == expected
+        expect(file_node.attributes['publish'].nil?).to eq(expected)
+        expect(file_node.attributes['preserve'].nil?).to eq(expected)
+        expect(file_node.attributes['shelve'].nil?).to eq(expected)
       end
 
       # check that the file nodes now have the correct size, mimetype
       aft_file_nodes=aft.xpath('//file')
-      aft_file_nodes.size.should == 10
-      aft_file_nodes[0].attributes['size'].value.should == '63468'
-      aft_file_nodes[0].attributes['mimetype'].value.should == 'image/tiff'
+      expect(aft_file_nodes.size).to eq(10)
+      expect(aft_file_nodes[0].attributes['size'].value).to eq('63468')
+      expect(aft_file_nodes[0].attributes['mimetype'].value).to eq('image/tiff')
       # the first file node should preserve the existing publish/preserve/shelve attributes set in the incoming content metadata and not overwrite them with the default for tiff
-      aft_file_nodes[0].attributes['publish'].value.should == 'yes'
-      aft_file_nodes[0].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[0].attributes['shelve'].value.should == 'yes'
+      expect(aft_file_nodes[0].attributes['publish'].value).to eq('yes')
+      expect(aft_file_nodes[0].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[0].attributes['shelve'].value).to eq('yes')
 
       # all other file nodes will have their publish/preserve/shelve attributes set
-      aft_file_nodes[1].attributes['size'].value.should == '465'
-      aft_file_nodes[1].attributes['mimetype'].value.should == 'image/jp2'
-      aft_file_nodes[1].attributes['publish'].value.should == 'yes'
-      aft_file_nodes[1].attributes['preserve'].value.should == 'no'
-      aft_file_nodes[1].attributes['shelve'].value.should == 'yes'
+      expect(aft_file_nodes[1].attributes['size'].value).to eq('465')
+      expect(aft_file_nodes[1].attributes['mimetype'].value).to eq('image/jp2')
+      expect(aft_file_nodes[1].attributes['publish'].value).to eq('yes')
+      expect(aft_file_nodes[1].attributes['preserve'].value).to eq('no')
+      expect(aft_file_nodes[1].attributes['shelve'].value).to eq('yes')
 
-      aft_file_nodes[2].attributes['size'].value.should == '450604'
-      aft_file_nodes[2].attributes['mimetype'].value.should == 'audio/x-wav'
-      aft_file_nodes[2].attributes['publish'].value.should == 'no'
-      aft_file_nodes[2].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[2].attributes['shelve'].value.should == 'no'
+      expect(aft_file_nodes[2].attributes['size'].value).to eq('450604')
+      expect(aft_file_nodes[2].attributes['mimetype'].value).to eq('audio/x-wav')
+      expect(aft_file_nodes[2].attributes['publish'].value).to eq('no')
+      expect(aft_file_nodes[2].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[2].attributes['shelve'].value).to eq('no')
 
-      aft_file_nodes[3].attributes['size'].value.should == '3151'
-      aft_file_nodes[3].attributes['mimetype'].value.should == 'application/pdf'
-      aft_file_nodes[3].attributes['publish'].value.should == 'yes'
-      aft_file_nodes[3].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[3].attributes['shelve'].value.should == 'yes'
+      expect(aft_file_nodes[3].attributes['size'].value).to eq('3151')
+      expect(aft_file_nodes[3].attributes['mimetype'].value).to eq('application/pdf')
+      expect(aft_file_nodes[3].attributes['publish'].value).to eq('yes')
+      expect(aft_file_nodes[3].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[3].attributes['shelve'].value).to eq('yes')
 
-      aft_file_nodes[4].attributes['size'].value.should == '3151'
-      aft_file_nodes[4].attributes['mimetype'].value.should == 'application/pdf'
-      aft_file_nodes[4].attributes['publish'].value.should == 'yes'
-      aft_file_nodes[4].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[4].attributes['shelve'].value.should == 'yes'
+      expect(aft_file_nodes[4].attributes['size'].value).to eq('3151')
+      expect(aft_file_nodes[4].attributes['mimetype'].value).to eq('application/pdf')
+      expect(aft_file_nodes[4].attributes['publish'].value).to eq('yes')
+      expect(aft_file_nodes[4].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[4].attributes['shelve'].value).to eq('yes')
 
-      aft_file_nodes[5].attributes['size'].value.should == '63468'
-      aft_file_nodes[5].attributes['mimetype'].value.should == 'image/tiff'
-      aft_file_nodes[5].attributes['publish'].value.should == 'no'
-      aft_file_nodes[5].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[5].attributes['shelve'].value.should == 'no'
+      expect(aft_file_nodes[5].attributes['size'].value).to eq('63468')
+      expect(aft_file_nodes[5].attributes['mimetype'].value).to eq('image/tiff')
+      expect(aft_file_nodes[5].attributes['publish'].value).to eq('no')
+      expect(aft_file_nodes[5].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[5].attributes['shelve'].value).to eq('no')
 
-      aft_file_nodes[6].attributes['size'].value.should == '42212'
-      aft_file_nodes[6].attributes['mimetype'].value.should == 'audio/mpeg'
-      aft_file_nodes[6].attributes['publish'].value.should == 'yes'
-      aft_file_nodes[6].attributes['preserve'].value.should == 'no'
-      aft_file_nodes[6].attributes['shelve'].value.should == 'yes'
+      expect(aft_file_nodes[6].attributes['size'].value).to eq('42212')
+      expect(aft_file_nodes[6].attributes['mimetype'].value).to eq('audio/mpeg')
+      expect(aft_file_nodes[6].attributes['publish'].value).to eq('yes')
+      expect(aft_file_nodes[6].attributes['preserve'].value).to eq('no')
+      expect(aft_file_nodes[6].attributes['shelve'].value).to eq('yes')
 
-      aft_file_nodes[7].attributes['size'].value.should == '63468'
-      aft_file_nodes[7].attributes['mimetype'].value.should == 'image/tiff'
-      aft_file_nodes[7].attributes['publish'].value.should == 'no'
-      aft_file_nodes[7].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[7].attributes['shelve'].value.should == 'no'
+      expect(aft_file_nodes[7].attributes['size'].value).to eq('63468')
+      expect(aft_file_nodes[7].attributes['mimetype'].value).to eq('image/tiff')
+      expect(aft_file_nodes[7].attributes['publish'].value).to eq('no')
+      expect(aft_file_nodes[7].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[7].attributes['shelve'].value).to eq('no')
 
-      aft_file_nodes[8].attributes['size'].value.should == '63468'
-      aft_file_nodes[8].attributes['mimetype'].value.should == 'image/tiff'
-      aft_file_nodes[8].attributes['publish'].value.should == 'no'
-      aft_file_nodes[8].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[8].attributes['shelve'].value.should == 'no'
+      expect(aft_file_nodes[8].attributes['size'].value).to eq('63468')
+      expect(aft_file_nodes[8].attributes['mimetype'].value).to eq('image/tiff')
+      expect(aft_file_nodes[8].attributes['publish'].value).to eq('no')
+      expect(aft_file_nodes[8].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[8].attributes['shelve'].value).to eq('no')
 
-      aft_file_nodes[9].attributes['size'].value.should == '63468'
-      aft_file_nodes[9].attributes['mimetype'].value.should == 'image/tiff'
-      aft_file_nodes[9].attributes['publish'].value.should == 'no'
-      aft_file_nodes[9].attributes['preserve'].value.should == 'yes'
-      aft_file_nodes[9].attributes['shelve'].value.should == 'no'
+      expect(aft_file_nodes[9].attributes['size'].value).to eq('63468')
+      expect(aft_file_nodes[9].attributes['mimetype'].value).to eq('image/tiff')
+      expect(aft_file_nodes[9].attributes['publish'].value).to eq('no')
+      expect(aft_file_nodes[9].attributes['preserve'].value).to eq('yes')
+      expect(aft_file_nodes[9].attributes['shelve'].value).to eq('no')
 
       # check that each resource node end with a type="file" (i.e. was not changed)
       aft_res_nodes=aft.xpath('//resource')
-      aft_res_nodes.size.should == 5
-      aft_res_nodes[0].attributes['type'].value.should == 'file' # first resource type should be set to file (which is the default if it contains no images)
-      aft_res_nodes[1].attributes['type'].value.should == 'file' # second resource type should be set to file (which is the default if it contains no images)
-      aft_res_nodes[2].attributes['type'].nil?.should == true # third resource type should be nil still
-      aft_res_nodes[3].attributes['type'].value.should == 'page' # fourth resource type should be set to page (which it started out as)
-      aft_res_nodes[4].attributes['type'].value.should == 'image' # fifth resource type should be set to image (which it started out as)
+      expect(aft_res_nodes.size).to eq(5)
+      expect(aft_res_nodes[0].attributes['type'].value).to eq('file') # first resource type should be set to file (which is the default if it contains no images)
+      expect(aft_res_nodes[1].attributes['type'].value).to eq('file') # second resource type should be set to file (which is the default if it contains no images)
+      expect(aft_res_nodes[2].attributes['type'].nil?).to eq(true) # third resource type should be nil still
+      expect(aft_res_nodes[3].attributes['type'].value).to eq('page') # fourth resource type should be set to page (which it started out as)
+      expect(aft_res_nodes[4].attributes['type'].value).to eq('image') # fifth resource type should be set to image (which it started out as)
 
       # check for imageData nodes being present for each file node that is an image
-      bef.xpath('//file/imageData').size.should == 0
-      aft.xpath('//file/imageData').size.should == 6
+      expect(bef.xpath('//file/imageData').size).to eq(0)
+      expect(aft.xpath('//file/imageData').size).to eq(6)
 
     end
 

--- a/spec/lib/findable_spec.rb
+++ b/spec/lib/findable_spec.rb
@@ -15,43 +15,43 @@ describe Dor::Assembly::Findable do
   it "should compute the new druid tree path without checking for existence" do
     @item = ExifableItem.new
     @item.druid = DruidTools::Druid.new 'druid:xx111yy2222'
-    @item.druid_tree_path(@root_dir1).should == "#{@root_dir1}/xx/111/yy/2222/xx111yy2222"
+    expect(@item.druid_tree_path(@root_dir1)).to eq("#{@root_dir1}/xx/111/yy/2222/xx111yy2222")
   end
 
   it "should compute the old druid tree path without checking for existence" do
     @item = ExifableItem.new
     @item.druid = DruidTools::Druid.new 'druid:xx111yy2222'
-    @item.old_druid_tree_path(@root_dir2).should == "#{@root_dir2}/xx/111/yy/2222"
+    expect(@item.old_druid_tree_path(@root_dir2)).to eq("#{@root_dir2}/xx/111/yy/2222")
   end
 
   it "should find the path to the content metadata file in the first possible root directory" do
     @item = Dor::Assembly::Item.new :druid => 'druid:aa111bb2222'
     exp_cm_file = "#{@root_dir1}/aa/111/bb/2222/#{@cm_file_name}"
-    @item.cm_file_name.should == exp_cm_file
+    expect(@item.cm_file_name).to eq(exp_cm_file)
   end
 
   it "should find the path to the content metadata file in the new location in the first possible root directory" do
     @item = Dor::Assembly::Item.new :druid => 'druid:gg111bb2222'
     exp_cm_file = "#{@root_dir1}/gg/111/bb/2222/gg111bb2222/metadata/#{@cm_file_name}"
-    @item.cm_file_name.should == exp_cm_file
+    expect(@item.cm_file_name).to eq(exp_cm_file)
   end
 
   it "should find the path to the content metadata file when in the second possible root directory" do
     @item = Dor::Assembly::Item.new :druid => 'druid:aa222cc3333'
     exp_cm_file = "#{@root_dir2}/aa/222/cc/3333/#{@cm_file_name}"
-    @item.cm_file_name.should == exp_cm_file
+    expect(@item.cm_file_name).to eq(exp_cm_file)
   end
 
   it "should find the path to the content metadata file when in the second possible root directory" do
     @item = Dor::Assembly::Item.new :druid => 'druid:gg222cc3333'
     exp_cm_file = "#{@root_dir2}/gg/222/cc/3333/gg222cc3333/metadata/#{@cm_file_name}"
-    @item.cm_file_name.should == exp_cm_file
+    expect(@item.cm_file_name).to eq(exp_cm_file)
   end
 
   it "should throw an exception when the object folder is found but the content metadata file is not found" do
     exp_msg = "Content metadata file contentMetadata.xml not found for hh222cc4444 in any of the root directories: spec/test_input,spec/test_input2"
     @item = Dor::Assembly::Item.new :druid =>  'druid:hh222cc4444'
-    lambda {@item.load_content_metadata}.should raise_error RuntimeError, exp_msg
+    expect {@item.load_content_metadata}.to raise_error RuntimeError, exp_msg
   end
 
 end

--- a/spec/lib/item_spec.rb
+++ b/spec/lib/item_spec.rb
@@ -8,37 +8,37 @@ describe Dor::Assembly::Item do
       @dru         = 'aa111bb2222'
       @druid       = DruidTools::Druid.new @dru
       @item = Dor::Assembly::Item.new :druid => @druid
-      @item.druid.should == @druid
-      @item.druid.druid.should == "druid:#{@dru}"
-      @item.druid.id.should == @dru
+      expect(@item.druid).to eq(@druid)
+      expect(@item.druid.druid).to eq("druid:#{@dru}")
+      expect(@item.druid.id).to eq(@dru)
     end
 
     it "should raise an error if the object folder cannot be found" do
       @dru         = 'xx111yy2222'
       @druid       = DruidTools::Druid.new @dru
       exp_msg = "Path to object xx111yy2222 not found in any of the root directories: spec/test_input,spec/test_input2"
-      lambda {@item = Dor::Assembly::Item.new :druid => @druid}.should raise_error RuntimeError, exp_msg
+      expect {@item = Dor::Assembly::Item.new :druid => @druid}.to raise_error RuntimeError, exp_msg
     end
 
     it "should return is_item? as true for object type == item" do
       @dru         = 'aa111bb2222'
       @item = Dor::Assembly::Item.new :druid => @dru
-      @item.stub(:object_type).and_return('item')
-      @item.is_item?.should be_truthy
+      allow(@item).to receive(:object_type).and_return('item')
+      expect(@item.is_item?).to be_truthy
     end
 
     it "should return is_item? as false for object type == set" do
       @dru         = 'aa111bb2222'
       @item = Dor::Assembly::Item.new :druid => @dru
-      @item.stub(:object_type).and_return('set')
-      @item.is_item?.should be_falsey
+      allow(@item).to receive(:object_type).and_return('set')
+      expect(@item.is_item?).to be_falsey
     end
 
     it "should return is_item? as false for object type not known" do
       @dru         = 'aa111bb2222'
       @item = Dor::Assembly::Item.new :druid => @dru
-      @item.stub(:object_type).and_return('')
-      @item.is_item?.should be_falsey
+      allow(@item).to receive(:object_type).and_return('')
+      expect(@item.is_item?).to be_falsey
     end
 
   end

--- a/spec/lib/jp2able_spec.rb
+++ b/spec/lib/jp2able_spec.rb
@@ -20,7 +20,7 @@ describe Dor::Assembly::Jp2able do
   describe '#Jp2ableItem' do
     it 'should be able to initialize our testing object' do
       basic_setup 'aa111bb2222', TMP_ROOT_DIR
-      @item.should be_a_kind_of Jp2ableItem
+      expect(@item).to be_a_kind_of Jp2ableItem
     end
   end
 
@@ -38,16 +38,16 @@ describe Dor::Assembly::Jp2able do
       jp2s = tifs.map { |t| t.sub /\.tif$/, '.jp2' }
 
       # Only tifs should exist.
-      @item.file_nodes.size.should == 3
-      tifs.all?  { |t| File.file? t }.should == true
-      jp2s.none? { |j| File.file? j }.should == true
+      expect(@item.file_nodes.size).to eq(3)
+      expect(tifs.all?  { |t| File.file? t }).to eq(true)
+      expect(jp2s.none? { |j| File.file? j }).to eq(true)
 
       # We now have jp2s since all resource types = image
       create_jp2s
       files = get_filenames(@item)
-      @item.file_nodes.size.should == 6
-      count_file_types(files,'.tif').should == 3
-      count_file_types(files,'.jp2').should == 3
+      expect(@item.file_nodes.size).to eq(6)
+      expect(count_file_types(files,'.tif')).to eq(3)
+      expect(count_file_types(files,'.jp2')).to eq(3)
     end
 
     it 'should create jp2 files only for resource type image or page' do
@@ -59,21 +59,21 @@ describe Dor::Assembly::Jp2able do
       bef_files = get_filenames(@item)
 
       # there should be 10 file nodes in total
-      @item.file_nodes.size.should == 10
-      count_file_types(bef_files,'.tif').should == 5
-      count_file_types(bef_files,'.jp2').should == 1
+      expect(@item.file_nodes.size).to eq(10)
+      expect(count_file_types(bef_files,'.tif')).to eq(5)
+      expect(count_file_types(bef_files,'.jp2')).to eq(1)
 
       create_jp2s
       # we now have two extra jps, only for the resource nodes that had type=image or page specified, but not for the others
-      @item.file_nodes.size.should == 12
+      expect(@item.file_nodes.size).to eq(12)
       aft_files = get_filenames(@item)
-      count_file_types(aft_files,'.tif').should == 5
-      count_file_types(aft_files,'.jp2').should == 3
+      expect(count_file_types(aft_files,'.tif')).to eq(5)
+      expect(count_file_types(aft_files,'.jp2')).to eq(3)
 
       # Read the XML file and check the file names.
       xml = Nokogiri::XML File.read(@item.cm_file_name)
       file_nodes = xml.xpath "//resource/file"
-      file_nodes.map { |fn| fn['id'] }.sort.should == ["file111.mp3", "file111.pdf", "file111.wav", "file112.pdf", "image111.jp2", "image111.tif", "image112.tif", "image113.tif", "image114.jp2", "image114.tif", "image115.jp2", "image115.tif"]
+      expect(file_nodes.map { |fn| fn['id'] }.sort).to eq(["file111.mp3", "file111.pdf", "file111.wav", "file112.pdf", "image111.jp2", "image111.tif", "image112.tif", "image113.tif", "image114.jp2", "image114.tif", "image115.jp2", "image115.tif"])
 
     end
 
@@ -86,21 +86,21 @@ describe Dor::Assembly::Jp2able do
       bef_files = get_filenames(@item)
 
       # there should be 3 file nodes in total
-      @item.file_nodes.size.should == 3
-      count_file_types(bef_files,'.tif').should == 3
-      count_file_types(bef_files,'.jp2').should == 0
+      expect(@item.file_nodes.size).to eq(3)
+      expect(count_file_types(bef_files,'.tif')).to eq(3)
+      expect(count_file_types(bef_files,'.jp2')).to eq(0)
 
       create_jp2s
       # we now have three jps
-      @item.file_nodes.size.should == 6
+      expect(@item.file_nodes.size).to eq(6)
       aft_files = get_filenames(@item)
-      count_file_types(aft_files,'.tif').should == 3
-      count_file_types(aft_files,'.jp2').should == 3
+      expect(count_file_types(aft_files,'.tif')).to eq(3)
+      expect(count_file_types(aft_files,'.jp2')).to eq(3)
 
       # Read the XML file and check the file names.
       xml = Nokogiri::XML File.read(@item.cm_file_name)
       file_nodes = xml.xpath "//resource/file"
-      file_nodes.map { |fn| fn['id'] }.sort.should == ["image111.jp2", "image111.tif", "image112.jp2", "image112.tif", "sub/image113.jp2", "sub/image113.tif"]
+      expect(file_nodes.map { |fn| fn['id'] }.sort).to eq(["image111.jp2", "image111.tif", "image112.jp2", "image112.tif", "sub/image113.jp2", "sub/image113.tif"])
 
     end
 
@@ -122,18 +122,18 @@ describe Dor::Assembly::Jp2able do
       bef_files = get_filenames(@item)
 
       # there should be 10 file nodes in total
-      @item.file_nodes.size.should == 10
-      count_file_types(bef_files,'.tif').should == 5
-      count_file_types(bef_files,'.jp2').should == 1
+      expect(@item.file_nodes.size).to eq(10)
+      expect(count_file_types(bef_files,'.tif')).to eq(5)
+      expect(count_file_types(bef_files,'.jp2')).to eq(1)
 
-      File.exists?(copy_jp2).should == true
+      expect(File.exists?(copy_jp2)).to eq(true)
 
       create_jp2s
       # we now have only one extra jp2, only for the resource nodes that had type=image or page specified, since one was not created because it was already there
-      @item.file_nodes.size.should == 11
+      expect(@item.file_nodes.size).to eq(11)
       aft_files = get_filenames(@item)
-      count_file_types(aft_files,'.tif').should == 5
-      count_file_types(aft_files,'.jp2').should == 2
+      expect(count_file_types(aft_files,'.tif')).to eq(5)
+      expect(count_file_types(aft_files,'.jp2')).to eq(2)
 
       # cleanup copied jp2
       system "rm #{copy_jp2}"
@@ -158,18 +158,18 @@ describe Dor::Assembly::Jp2able do
       bef_files = get_filenames(@item)
 
       # there should be 10 file nodes in total
-      @item.file_nodes.size.should == 10
-      count_file_types(bef_files,'.tif').should == 5
-      count_file_types(bef_files,'.jp2').should == 1
+      expect(@item.file_nodes.size).to eq(10)
+      expect(count_file_types(bef_files,'.tif')).to eq(5)
+      expect(count_file_types(bef_files,'.jp2')).to eq(1)
 
-      File.exists?(copy_jp2).should == true
+      expect(File.exists?(copy_jp2)).to eq(true)
 
       create_jp2s
 
-      @item.file_nodes.size.should == 11
+      expect(@item.file_nodes.size).to eq(11)
       aft_files = get_filenames(@item)
-      count_file_types(aft_files,'.tif').should == 5
-      count_file_types(aft_files,'.jp2').should == 2
+      expect(count_file_types(aft_files,'.tif')).to eq(5)
+      expect(count_file_types(aft_files,'.jp2')).to eq(2)
 
       # cleanup copied jp2
       system "rm #{copy_jp2}"
@@ -189,18 +189,18 @@ describe Dor::Assembly::Jp2able do
       bef_files = get_filenames(@item)
 
       # there should be 6 file nodes in total to start
-      @item.file_nodes.size.should == 6
-      count_file_types(bef_files,'.tif').should == 5
-      count_file_types(bef_files,'.jp2').should == 1
+      expect(@item.file_nodes.size).to eq(6)
+      expect(count_file_types(bef_files,'.tif')).to eq(5)
+      expect(count_file_types(bef_files,'.jp2')).to eq(1)
 
       create_jp2s
 
       # we now have three extra jp2, one for each tif that didn't have a matching dpg style jp2
       # even if the jp2 does not exist in the original content metadata, if a matching one is found, a derivative won't be created
-      @item.file_nodes.size.should == 9  # there are 9 total nodes, 4 jp2 and 5 tif
+      expect(@item.file_nodes.size).to eq(9)  # there are 9 total nodes, 4 jp2 and 5 tif
       aft_files = get_filenames(@item)
-      count_file_types(aft_files,'.tif').should == 5
-      count_file_types(aft_files,'.jp2').should == 4
+      expect(count_file_types(aft_files,'.tif')).to eq(5)
+      expect(count_file_types(aft_files,'.jp2')).to eq(4)
 
     end
 
@@ -217,16 +217,16 @@ describe Dor::Assembly::Jp2able do
       bef_files = get_filenames(@item)
 
       # there should be 6 file nodes in total to start
-      @item.file_nodes.size.should == 6
-      count_file_types(bef_files,'.tif').should == 5
-      count_file_types(bef_files,'.jp2').should == 1
+      expect(@item.file_nodes.size).to eq(6)
+      expect(count_file_types(bef_files,'.tif')).to eq(5)
+      expect(count_file_types(bef_files,'.jp2')).to eq(1)
 
       create_jp2s
 
-      @item.file_nodes.size.should == 11
+      expect(@item.file_nodes.size).to eq(11)
       aft_files = get_filenames(@item)
-      count_file_types(aft_files,'.tif').should == 5
-      count_file_types(aft_files,'.jp2').should == 6
+      expect(count_file_types(aft_files,'.tif')).to eq(5)
+      expect(count_file_types(aft_files,'.jp2')).to eq(6)
 
     end
 
@@ -252,7 +252,7 @@ describe Dor::Assembly::Jp2able do
       resource_node = @item.cm.xpath('//resource').first
 
       @item.add_jp2_file_node resource_node, 'foo.tif'
-      @item.cm.should be_equivalent_to exp_xml
+      expect(@item.cm).to be_equivalent_to exp_xml
     end
 
   end

--- a/spec/robots/assembly/accessioning_initiate_spec.rb
+++ b/spec/robots/assembly/accessioning_initiate_spec.rb
@@ -5,33 +5,33 @@ describe Robots::DorRepo::Assembly::AccessioningInitiate do
   before :each do
     @druid='aa222cc3333'
     setup_work_item(@druid)
-    RestClient.stub(:post) # don't actually make the RestClient calls, just assume they work
+    allow(RestClient).to receive(:post) # don't actually make the RestClient calls, just assume they work
     @r = Robots::DorRepo::Assembly::AccessioningInitiate.new(:druid=>@druid)
   end
 
   it "should initiate accessioning for type=item" do
     setup_assembly_item(@druid,:item)
-    @assembly_item.should_receive(:initiate_accessioning)
+    expect(@assembly_item).to receive(:initiate_accessioning)
     @r.perform(@work_item)
   end
 
   it "should initiate accessioning for type=set" do
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_receive(:initiate_accessioning)
+    expect(@assembly_item).to receive(:initiate_accessioning)
     @r.perform(@work_item)
   end
 
   it "should always initiate accessioning regardless of object type and configuration of items_only=false" do
     Dor::Config.configure.assembly.items_only=false
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_receive(:initiate_accessioning)
+    expect(@assembly_item).to receive(:initiate_accessioning)
     @r.perform(@work_item)
   end
 
   it "should always initiate accessioning regardless of object type and configuration of items_only=true" do
     Dor::Config.configure.assembly.items_only=true
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_receive(:initiate_accessioning)
+    expect(@assembly_item).to receive(:initiate_accessioning)
     @r.perform(@work_item)
   end
 

--- a/spec/robots/assembly/checksum_compute_spec.rb
+++ b/spec/robots/assembly/checksum_compute_spec.rb
@@ -5,33 +5,33 @@ describe Robots::DorRepo::Assembly::ChecksumCompute do
   before :each do
     @druid='aa222cc3333'
     setup_work_item(@druid)
-    Dor::Assembly::Item.stub(:new).and_return(@assembly_item)
+    allow(Dor::Assembly::Item).to receive(:new).and_return(@assembly_item)
     @r = Robots::DorRepo::Assembly::ChecksumCompute.new(:druid=>@druid)
   end
 
   it "should compute checksums for type=item" do
     setup_assembly_item(@druid,:item)
-    @assembly_item.should_receive(:is_item?)
-    @assembly_item.should_receive(:load_content_metadata)
-    @assembly_item.should_receive(:compute_checksums)
+    expect(@assembly_item).to receive(:is_item?)
+    expect(@assembly_item).to receive(:load_content_metadata)
+    expect(@assembly_item).to receive(:compute_checksums)
     @r.perform(@work_item)
   end
 
   it "should not compute checksums for type=set if configured that way" do
     Dor::Config.configure.assembly.items_only=true
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_receive(:is_item?)
-    @assembly_item.should_not_receive(:load_content_metadata)
-    @assembly_item.should_not_receive(:compute_checksums)
+    expect(@assembly_item).to receive(:is_item?)
+    expect(@assembly_item).not_to receive(:load_content_metadata)
+    expect(@assembly_item).not_to receive(:compute_checksums)
     @r.perform(@work_item)
   end
 
   it "should compute checksums for type=set if configured that way" do
     Dor::Config.configure.assembly.items_only=false
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_not_receive(:is_item?)
-    @assembly_item.should_receive(:load_content_metadata)
-    @assembly_item.should_receive(:compute_checksums)
+    expect(@assembly_item).not_to receive(:is_item?)
+    expect(@assembly_item).to receive(:load_content_metadata)
+    expect(@assembly_item).to receive(:compute_checksums)
     @r.perform(@work_item)
   end
 

--- a/spec/robots/assembly/exif_collect_spec.rb
+++ b/spec/robots/assembly/exif_collect_spec.rb
@@ -5,34 +5,34 @@ describe Robots::DorRepo::Assembly::ExifCollect do
   before :each do
     @druid='aa222cc3333'
     setup_work_item(@druid)
-    Dor::Assembly::Item.stub(:new).and_return(@assembly_item)
+    allow(Dor::Assembly::Item).to receive(:new).and_return(@assembly_item)
     @r = Robots::DorRepo::Assembly::ExifCollect.new(:druid=>@druid)
   end
 
   it "should collect exif for type=item" do
     Dor::Config.configure.assembly.items_only=true
     setup_assembly_item(@druid,:item)
-    @assembly_item.should_receive(:is_item?)
-    @assembly_item.should_receive(:load_content_metadata)
-    @assembly_item.should_receive(:collect_exif_info)
+    expect(@assembly_item).to receive(:is_item?)
+    expect(@assembly_item).to receive(:load_content_metadata)
+    expect(@assembly_item).to receive(:collect_exif_info)
     @r.perform(@work_item)
   end
 
   it "should not collect exif for type=set if configured that way" do
     Dor::Config.configure.assembly.items_only=true
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_receive(:is_item?)
-    @assembly_item.should_not_receive(:load_content_metadata)
-    @assembly_item.should_not_receive(:collect_exif_info)
+    expect(@assembly_item).to receive(:is_item?)
+    expect(@assembly_item).not_to receive(:load_content_metadata)
+    expect(@assembly_item).not_to receive(:collect_exif_info)
     @r.perform(@work_item)
   end
 
   it "should collect exif for type=set if configured that way" do
     Dor::Config.configure.assembly.items_only=false
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_not_receive(:is_item?)
-    @assembly_item.should_receive(:load_content_metadata)
-    @assembly_item.should_receive(:collect_exif_info)
+    expect(@assembly_item).not_to receive(:is_item?)
+    expect(@assembly_item).to receive(:load_content_metadata)
+    expect(@assembly_item).to receive(:collect_exif_info)
     @r.perform(@work_item)
   end
 

--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -5,34 +5,34 @@ describe Robots::DorRepo::Assembly::Jp2Create do
   before :each do
     @druid='aa222cc3333'
     setup_work_item(@druid)
-    Dor::Assembly::Item.stub(:new).and_return(@assembly_item)
+    allow(Dor::Assembly::Item).to receive(:new).and_return(@assembly_item)
     @r = Robots::DorRepo::Assembly::Jp2Create.new(:druid=>@druid)
   end
 
   it "should create jp2 for type=item" do
     Dor::Config.configure.assembly.items_only=true
     setup_assembly_item(@druid,:item)
-    @assembly_item.should_receive(:is_item?)
-    @assembly_item.should_receive(:load_content_metadata)
-    @assembly_item.should_receive(:create_jp2s)
+    expect(@assembly_item).to receive(:is_item?)
+    expect(@assembly_item).to receive(:load_content_metadata)
+    expect(@assembly_item).to receive(:create_jp2s)
     @r.perform(@work_item)
   end
 
   it "should not create jp2 for type=set if configured that way" do
     Dor::Config.configure.assembly.items_only=true
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_receive(:is_item?)
-    @assembly_item.should_not_receive(:load_content_metadata)
-    @assembly_item.should_not_receive(:create_jp2s)
+    expect(@assembly_item).to receive(:is_item?)
+    expect(@assembly_item).not_to receive(:load_content_metadata)
+    expect(@assembly_item).not_to receive(:create_jp2s)
     @r.perform(@work_item)
   end
 
   it "should create jp2 for type=set if configured that way" do
     Dor::Config.configure.assembly.items_only=false
     setup_assembly_item(@druid,:set)
-    @assembly_item.should_not_receive(:is_item?)
-    @assembly_item.should_receive(:load_content_metadata)
-    @assembly_item.should_receive(:create_jp2s)
+    expect(@assembly_item).not_to receive(:is_item?)
+    expect(@assembly_item).to receive(:load_content_metadata)
+    expect(@assembly_item).to receive(:create_jp2s)
     @r.perform(@work_item)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,20 +36,20 @@ end
 
 def setup_work_item(druid)
   @work_item=double("work_item")
-  @work_item.stub('druid').and_return(druid)
+  allow(@work_item).to receive('druid').and_return(druid)
 end
 
 def setup_assembly_item(druid,obj_type)
   @assembly_item=double("assembly_item")
-  @assembly_item.stub('druid').and_return(druid)
+  allow(@assembly_item).to receive('druid').and_return(druid)
   if obj_type==:item
-    @assembly_item.stub(:object_type).and_return('item')
-    @assembly_item.stub(:is_item?).and_return(true)
+    allow(@assembly_item).to receive(:object_type).and_return('item')
+    allow(@assembly_item).to receive(:is_item?).and_return(true)
   else
-    @assembly_item.stub(:object_type).and_return(obj_type.to_s)
-    @assembly_item.stub(:is_item?).and_return(false)
+    allow(@assembly_item).to receive(:object_type).and_return(obj_type.to_s)
+    allow(@assembly_item).to receive(:is_item?).and_return(false)
   end
-  Dor::Assembly::Item.stub(:new).and_return(@assembly_item)
+  allow(Dor::Assembly::Item).to receive(:new).and_return(@assembly_item)
 end
 
 def kdu_missing?


### PR DESCRIPTION
This conversion is done by Transpec 3.1.2 with the following command:
    transpec

* 209 conversions
    from: obj.should
      to: expect(obj).to

* 193 conversions
    from: == expected
      to: eq(expected)

* 26 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 19 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 9 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 6 conversions
    from: lambda { }.should
      to: expect { }.to

* 1 conversion
    from: lambda { }.should_not
      to: expect { }.not_to

For more details: https://github.com/yujinakayama/transpec#supported-conversions