### PR TITLE
Remove bluepill, because assembly doesn't use it directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'assembly-image', '>=1.6.9'
 gem 'assembly-objectfile', '>=1.6.6'
-gem 'bluepill', '>=0.1.3'
 gem 'dor-services', '~> 6.0'
 gem 'druid-tools'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,6 @@ DEPENDENCIES
   assembly-image (>= 1.6.9)
   assembly-objectfile (>= 1.6.6)
   awesome_print
-  bluepill (>= 0.1.3)
   capistrano (~> 3)
   capistrano-bundler
   capistrano-rvm


### PR DESCRIPTION
bluepill is a dependency of robot-controller