### PR TITLE
Initialize honeybadger

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -10,6 +10,8 @@ ROBOT_ROOT  = File.expand_path(File.dirname(__FILE__) + '/..')
   $LOAD_PATH.unshift File.join(ROBOT_ROOT, d)
 end
 
+require 'honeybadger'
+
 # Set up the robot logger.
 require 'logger'
 ROBOT_LOG       = Logger.new(File.join(ROBOT_ROOT, "log/#{environment}.log"))


### PR DESCRIPTION
Because Bundler.require is never used, we need to require honeybadger explicitly