### PR TITLE
[WIP] Fix issues with jp2able tests so it uses tmp folder correctly

### DIFF
--- a/lib/content_metadata.rb
+++ b/lib/content_metadata.rb
@@ -7,7 +7,7 @@ module Dor::Assembly
   module ContentMetadata
     include StubContentMetadataParser
 
-    attr_accessor :cm, :stub_cm, :cm_handle, :druid, :root_dir
+    attr_accessor :cm, :stub_cm, :cm_handle, :druid, :root_dir, :path_to_object
     attr_writer :cm_file_name, :stub_cm_file_name
 
     # return the location to store or load the contentMetadata.xml file (could be in either the new or old location)

--- a/spec/lib/jp2able_spec.rb
+++ b/spec/lib/jp2able_spec.rb
@@ -7,8 +7,8 @@ describe Dor::Assembly::Jp2able do
     @cm_file_name = Dor::Config.assembly.cm_file_name
     @item              = Dor::Assembly::Item.new(druid: dru)
     @item.root_dir     = root_dir
-    @item.path_to_object # this will find the path to the object and set the folder_style -- it is only necessary to call this in test setup
-    # since we don't actually call the Dor::Assembly::Item initializer in tests like we do actual code (where it does get called)
+    @item.path_to_object = nil # this will allow us to override the path to the object to use the root_dir we overrode above
+    #  it is only necessary to clear this accessor in test setup since it otherwise gets set in the initializer and cached
     @dummy_xml = '<contentMetadata><resource></resource></contentMetadata>'
   end
 


### PR DESCRIPTION
Not necessary after #126 ??

The `Item` initializer is calling `.check_for_path` (https://github.com/sul-dlss/assembly/blob/master/lib/item.rb#L25-L27) which in turn calls `.path_to_object` which then caches the value before we had a chance to reset the value of `root_dir` in the tests.  We need to clear this cached value after the initializer runs in the tests so we can use our modified root_dir. 